### PR TITLE
Add Close first BlinkStick method

### DIFF
--- a/src/blinkstick/BlinkStick.java
+++ b/src/blinkstick/BlinkStick.java
@@ -292,6 +292,16 @@ public class BlinkStick {
 		}
 		return null;
 	}
+		
+	/**
+	 * Close first BlinkStick connected to the computer
+	 */
+	public void closeFirst() {
+	    try {
+	        this.device.close();
+	    } catch (IOException e) {
+	    }
+	}
 
 	/** Find BlinkStick by serial number
 	 * 


### PR DESCRIPTION
This method close first BlinkStick connected to the computer. This PR is essential if you use any BlinkStick in a loop or in a serial.